### PR TITLE
Switches to using addressable/uri so it can handle underscores in subdomains

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,2 +1,5 @@
 source :rubygems
+
+gem 'addressable'
+
 gemspec

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,11 +2,13 @@ PATH
   remote: .
   specs:
     sinatra-subdomain (0.1.2)
+      addressable
       sinatra
 
 GEM
   remote: http://rubygems.org/
   specs:
+    addressable (2.3.5)
     awesome_print (1.1.0)
     coderay (1.0.8)
     diff-lcs (1.1.3)
@@ -16,7 +18,7 @@ GEM
       method_source (~> 0.8)
       slop (~> 3.4)
     rack (1.5.2)
-    rack-protection (1.3.2)
+    rack-protection (1.5.0)
       rack
     rack-test (0.6.2)
       rack (>= 1.0)
@@ -29,17 +31,18 @@ GEM
     rspec-expectations (2.12.1)
       diff-lcs (~> 1.1.3)
     rspec-mocks (2.12.2)
-    sinatra (1.3.4)
+    sinatra (1.4.3)
       rack (~> 1.4)
-      rack-protection (~> 1.3)
-      tilt (~> 1.3, >= 1.3.3)
+      rack-protection (~> 1.4)
+      tilt (~> 1.3, >= 1.3.4)
     slop (3.4.3)
-    tilt (1.3.3)
+    tilt (1.4.1)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
+  addressable
   awesome_print
   pry
   rack-test

--- a/lib/sinatra/subdomain.rb
+++ b/lib/sinatra/subdomain.rb
@@ -1,5 +1,5 @@
 require "sinatra/base"
-require "uri"
+require "addressable/uri"
 
 module Sinatra
   module Subdomain
@@ -9,7 +9,7 @@ module Sinatra
 
     module Helpers
       def subdomain
-        uri = URI.parse("http://#{request.env["HTTP_HOST"]}")
+        uri = Addressable::URI.parse("http://#{request.env["HTTP_HOST"]}")
         parts = uri.host.split(".")
         parts.pop(settings.tld_size + 1)
         parts.first

--- a/sinatra-subdomain.gemspec
+++ b/sinatra-subdomain.gemspec
@@ -18,6 +18,7 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
 
   s.add_dependency "sinatra"
+  s.add_dependency "addressable"
   s.add_development_dependency "rspec"
   s.add_development_dependency "rake"
   s.add_development_dependency "rack-test"

--- a/spec/support/subdomain_shared.rb
+++ b/spec/support/subdomain_shared.rb
@@ -70,4 +70,20 @@ shared_examples_for "subdomain" do
       last_response.body.should eql("about")
     end
   end
+
+  context "when an underscore is included in the subdomain" do
+    it "renders root page" do
+      header "HOST", "example_domain#{tld}"
+      get "/"
+
+      last_response.body.should eql("root")
+    end
+
+    it "renders about page" do
+      header "HOST", "example_domain#{tld}"
+      get "/about"
+
+      last_response.body.should eql("about")
+    end
+  end
 end


### PR DESCRIPTION
Using addressable - https://github.com/sporkmonger/addressable it handles underscores better than standard uri. Currently with an underscore in the subdomain it returns "URI::InvalidURIError: the scheme http does not accept registry part: sub_domain.domain.com (or bad hostname?)"
