### PR TITLE
Add support for multiple subdomains

### DIFF
--- a/lib/sinatra/subdomain.rb
+++ b/lib/sinatra/subdomain.rb
@@ -12,7 +12,7 @@ module Sinatra
         uri = URI.parse("http://#{request.env["HTTP_HOST"]}")
         parts = uri.host.split(".")
         parts.pop(settings.tld_size + 1)
-        parts.first
+        parts.empty? ? nil : parts.join('.')
       end
     end
 

--- a/lib/sinatra/subdomain/version.rb
+++ b/lib/sinatra/subdomain/version.rb
@@ -3,7 +3,7 @@ module Sinatra
     module Version
       MAJOR = 0
       MINOR = 1
-      PATCH = 2
+      PATCH = 3
       STRING = "#{MAJOR}.#{MINOR}.#{PATCH}"
     end
   end

--- a/spec/support/subdomain_shared.rb
+++ b/spec/support/subdomain_shared.rb
@@ -7,6 +7,11 @@ shared_examples_for "subdomain" do
         register Sinatra::Subdomain
         set :tld_size, _tld.split(".").size - 1
 
+        subdomain "foo.bar" do
+          get("/") { "multiple: #{subdomain}" }
+          get("/about") { "multiple: about #{subdomain}" }
+        end
+
         subdomain :foo do
           get("/") { "set: #{subdomain}" }
           get("/about") { "set: about #{subdomain}" }
@@ -20,6 +25,22 @@ shared_examples_for "subdomain" do
         get("/") { "root" }
         get("/about") { "about" }
       end
+    end
+  end
+
+  context "when a multiple subdomain is required" do
+    it "renders root page" do
+      header "HOST", "foo.bar.example#{tld}"
+      get "/"
+
+      last_response.body.should eql("multiple: foo.bar")
+    end
+
+    it "renders about page" do
+      header "HOST", "foo.bar.example#{tld}"
+      get "/about"
+
+      last_response.body.should eql("multiple: about foo.bar")
     end
   end
 


### PR DESCRIPTION
## Allow support for multiple subdomains

Handy when you need to deal with something like `http://integration.foo.bar.example.com` when for example `foo` and/or `bar` could change for the same application. You will be able to deal with that instead of getting `integration` only without knowing about the others